### PR TITLE
Propagate Ninja's exit code to the container script.

### DIFF
--- a/ninja
+++ b/ninja
@@ -17,7 +17,14 @@ if (os.platform() === 'darwin') {
 
 let cmd = path.join(__dirname, 'binaries', binary);
 let args = process.argv.slice(2);
-spawn(cmd, args, {
+let ps = spawn(cmd, args, {
 	shell: true,
 	stdio: 'inherit'
+});
+ps.on('error', function(code) {
+	process.stderr.write('Unable to spawn ninja\n');
+	process.exit(255); // use a code not used by Ninja
+});
+ps.on('close', function(code) {
+	process.exit(code);
 });


### PR DESCRIPTION
Otherwise Ninja always exits with a 0 success code.