### PR TITLE
Surround command in quotes

### DIFF
--- a/ninja
+++ b/ninja
@@ -17,7 +17,7 @@ if (os.platform() === 'darwin') {
 
 let cmd = path.join(__dirname, 'binaries', binary);
 let args = process.argv.slice(2);
-let ps = spawn(cmd, args, {
+let ps = spawn(`"${cmd}"`, args, {
 	shell: true,
 	stdio: 'inherit'
 });


### PR DESCRIPTION
## Summary
This fixes #2, where execution breaks if the project directory contains a space in it.

## How to test
1. Use this branch in a project with a space in its path by adding `"ninja-binaries": "Banno/ninja-binaries#quote-command"` in its *package.json*
1. Execute `node_modules/.bin/ninja`
   - [ ] There should be no errors